### PR TITLE
Fixed empty save folder when using "reconnect" on some clients + .

### DIFF
--- a/share/src/main/java/wdl/WDL.java
+++ b/share/src/main/java/wdl/WDL.java
@@ -1000,6 +1000,9 @@ public class WDL {
 	 */
 	private void loadServerProps() {
 		baseFolderName = getBaseFolderName();
+		if (baseFolderName == null || baseFolderName == "") {
+			throw new RuntimeException("baseFolderName is empty ! This can cause numerous weird issues, like the mod zipping your whole .minecraft, so the mod crashed on purpose. Please report this on Github.");
+		}
 		serverProps = new Configuration(globalProps);
 
 		File savesFolder = new File(minecraft.gameDir, "saves");
@@ -1475,10 +1478,12 @@ public class WDL {
 		try {
 			if (minecraft.getCurrentServerData() != null) {
 				String name = minecraft.getCurrentServerData().serverName;
-
-				if (name.equals(I18n.format("selectServer.defaultName"))) {
+				
+				// Empty name = using the "reconnect" feature on some clients/mods
+				if (name == null || name == "" || name.equals(I18n.format("selectServer.defaultName"))) {
 					// Direct connection using domain name or IP (and port)
 					name = minecraft.getCurrentServerData().serverIP;
+					name = name.replace(":25565", "");
 				}
 
 				return name;

--- a/share/src/main/resources/assets/wdl/lang/fr_fr.lang
+++ b/share/src/main/resources/assets/wdl/lang/fr_fr.lang
@@ -306,8 +306,8 @@ wdl.messages.saving.mapItemDataSaved=Carte enregistrée.
 
 wdl.messages.onWorldLoad.sameServer=onWorldLoad: même serveur!
 wdl.messages.onWorldLoad.differentServer=onWorldLoad: serveur différent!
-wdl.messages.onWorldLoad.spigot=Server brand = %s.  Using spigot track distances.
-wdl.messages.onWorldLoad.vanilla=Server brand = %s.  Using vanilla track distances.
+wdl.messages.onWorldLoad.spigot=Marque du serveur = %s.  Utilisations des distances aux entitées de Spigot.
+wdl.messages.onWorldLoad.vanilla=Marque du serveur = %s.  Utilisations des distances aux entitées de Minecraft Vanilla.
 
 wdl.messages.onBlockEvent.noteblock=onBlockEvent: Note Block: %s pitch: %s - %s
 
@@ -343,83 +343,83 @@ wdl.messages.onGuiClosedWarning.failedToFindDoubleChest=Impossible d'enregistrer
 
 wdl.messages.generalInfo.downloadStarted=Début du téléchargement
 wdl.messages.generalInfo.downloadStopped=Téléchargement arrêté.
-wdl.messages.generalInfo.saveStarted=Save started.
-wdl.messages.generalInfo.saveComplete.startingAgain=Save complete. Starting download again.
-wdl.messages.generalInfo.saveComplete.done=Save complete. Your single player file is ready to play!
-wdl.messages.generalInfo.worldChanged=World change detected. Download will start once current save completes.
-wdl.messages.generalInfo.downloadCanceled=Download canceled.
-wdl.messages.generalInfo.seedSet=Setting single-player world seed to %s.
-wdl.messages.generalInfo.seedAndGenSet=Setting single-player world seed to %s and using the default terrain generator (you can change the generator in the generator options)
+wdl.messages.generalInfo.saveStarted=Sauvegarde démarrée.
+wdl.messages.generalInfo.saveComplete.startingAgain=Sauvegarde terminée. Début du téléchargement à nouveau.
+wdl.messages.generalInfo.saveComplete.done=Sauvegarde terminée. Votre monde solo est prêt à être joué!
+wdl.messages.generalInfo.worldChanged=Changement de monde détecté. Le téléchargement va démarrer une fois que le téléchargement actuel est terminé.
+wdl.messages.generalInfo.downloadCanceled=Téléchargement annulé.
+wdl.messages.generalInfo.seedSet=Changement de la graine solo à %s.
+wdl.messages.generalInfo.seedAndGenSet=Changement de la graine solo à %s en utilisant le générateur de terrain par défaut (vous pouvez changer le générateur dans les options du générateur)
 
-wdl.messages.generalError.failedToImportTE=Failed to import tile entities for chunk at %s, %s: %s
-wdl.messages.generalError.failedToSaveChunk=Chunk at position %s, %s cannot be saved!  (%s)
-wdl.messages.generalError.forbidden=The server forbids downloading this world!
-wdl.messages.generalError.failedToBackUp=Error while backing up world: %s
-wdl.messages.generalError.failedToSetUpEntityUI=Error setting up Entity List UI: %s
-wdl.messages.generalError.failedToSaveEntity=Failed to save entity %s for chunk at %s, %s: %s
-wdl.messages.generalError.failedToSaveTE=Failed to save tile entity %s at %s for chunk at %s, %s: %s
+wdl.messages.generalError.failedToImportTE=Importation des TileEntities ratée pour le chunk à %s, %s: %s
+wdl.messages.generalError.failedToSaveChunk=Le chunk à la position %s, %s ne peut pas être sauvegardé!  (%s)
+wdl.messages.generalError.forbidden=Le serveur n'autorise pas le téléchargement de ce monde!
+wdl.messages.generalError.failedToBackUp=Erreur pendant la backup du monde: %s
+wdl.messages.generalError.failedToSetUpEntityUI=Erreur pendant l'initialisation de l'UI pour la liste des entitées: %s
+wdl.messages.generalError.failedToSaveEntity=Sauvegarde de l'entitée %s ratée pour le chunk à %s, %s: %s
+wdl.messages.generalError.failedToSaveTE=Sauvegarde de la TileEntity %s à %s ratée pour le chunk à %s, %s: %s
 
-wdl.messages.updates.releaseCount=Found %s releases.
-wdl.messages.updates.failedToFindMatchingRelease=Could not find a release matching %s.  You may be running a version that hasn't been released yet.
-wdl.messages.updates.failedToFindMetadata=Could not find metadata for release %s.  Skipping hashing.
-wdl.messages.updates.newRelease=New version available!  You are running %s; the newest version is %s.  %s.
-wdl.messages.updates.newRelease.updateLink=Update here
-wdl.messages.updates.incorrectHash=Bad hash for %s (relative to %s): Expected MD5 in %s, got MD5 of %s.
-wdl.messages.updates.hashException=Bad hash for %s (relative to %s): Expected MD5 in %s, instead a %s was thrown.
-wdl.messages.updates.badHashesFound=Some files have invalid hashes!  Your installation may be corrupt or compromised.  Please use caution, and consider redownloading from the %s.
-wdl.messages.updates.updateCheckError=Failed to perform update check: %s.
-wdl.messages.updates.usingCachedUpdates=Using cached version list.
-wdl.messages.updates.grabingUpdatesFromGithub=Loading verison list from GitHub releases.
+wdl.messages.updates.releaseCount=Trouvé %s releases.
+wdl.messages.updates.failedToFindMatchingRelease=Aucune release trouvée correspondant à %s.  Vous pourriez être sur une version non publiée.
+wdl.messages.updates.failedToFindMetadata=Pas de metadata trouvée pour la release %s. Passage du hashing.
+wdl.messages.updates.newRelease=Nouvelle version disponible!  Vous êtes sur la %s; la dernière version disponible est la %s.  %s.
+wdl.messages.updates.newRelease.updateLink=Mise à jour ici
+wdl.messages.updates.incorrectHash=Mauvais hash pour %s (relatif à %s): Attendait un MD5 de %s, eu un MD5 de %s.
+wdl.messages.updates.hashException=Mauvais hash pour %s (relatif à %s): Attendait un MD5 de %s, à la place une %s a été levée.
+wdl.messages.updates.badHashesFound=Certains fichiers ont des hash invalides!  Votre installation peut être corrompue ou endommagée.  Utilisez avec précaution, et envisagez de retélécharger le mod %s.
+wdl.messages.updates.updateCheckError=Recherche de mises à jour ratée: %s.
+wdl.messages.updates.usingCachedUpdates=Utilisation de la liste de version en cache.
+wdl.messages.updates.grabingUpdatesFromGithub=Chargement de la liste des versions depuis Github.
 
-wdl.messages.permissions.init=Sending plugin channel registration.
-wdl.messages.permissions.packet0=Received settings packet #0: [canUseFunctionsUnknownToServer=%s]
-wdl.messages.permissions.packet1=Received settings packet #1: [canDownloadInGeneral=%s, canCacheChunks=%s, saveRadius=%s, canSaveEntities=%s, canSaveTileEntities=%s, canSaveContainers=%s]
-wdl.messages.permissions.packet2=Received settings packet #2: [entityRanges=(total of %s)]
-wdl.messages.permissions.packet3=Received settings packet #3: [canRequestPermissions=%s, requestMessage=(%s long, HashCode of %s)]
-wdl.messages.permissions.packet4=Received settings packet #4: [chunkOverrides=(%s groups, %s total ranges)]
-wdl.messages.permissions.packet5.added=Received settings packet #5: Added %s ChunkRanges to %s.
-wdl.messages.permissions.packet5.set=Received settings packet #5: Changed list of ChunkRanges to %s total in %s.
-wdl.messages.permissions.packet6=Received settings packet #6: Removed %s ChunkRanges from %s with tags matching %s.
-wdl.messages.permissions.packet7=Received settings packet #7: Replaced %s ChunkRanges in %s that had a tag of %s with %s new ranges.
-wdl.messages.permissions.unknownPacket=Received unknown settings packet #%s.  See log for binary contents.  
+wdl.messages.permissions.init=Envoi de l'initialisation du channel à plugins
+wdl.messages.permissions.packet0=Réception du packet de paramètre #0: [canUseFunctionsUnknownToServer=%s]
+wdl.messages.permissions.packet1=Réception du packet de paramètret #1: [canDownloadInGeneral=%s, canCacheChunks=%s, saveRadius=%s, canSaveEntities=%s, canSaveTileEntities=%s, canSaveContainers=%s]
+wdl.messages.permissions.packet2=Réception du packet de paramètre #2: [entityRanges=(total de %s)]
+wdl.messages.permissions.packet3=Réception du packet de paramètre #3: [canRequestPermissions=%s, requestMessage=(%s long, HashCode de %s)]
+wdl.messages.permissions.packet4=Réception du packet de paramètre #4: [chunkOverrides=(%s groupes, %s rayon total)]
+wdl.messages.permissions.packet5.added=Réception du packet de paramètre #5: Ajout de %s ChunkRanges à %s.
+wdl.messages.permissions.packet5.set=Réception du packet de paramètre #5: Changement de la liste ChunkRanges à %s total en %s.
+wdl.messages.permissions.packet6=Réception du packet de paramètre #6: %s enlevé de ChunkRanges de %s avec des tags correspondant à %s.
+wdl.messages.permissions.packet7=Réception du packet de paramètre #7: %s remplacé dans ChunkRanges dans %s qui avait un tag de %s avec %s nouveau rayon.
+wdl.messages.permissions.unknownPacket=Réception d'un packet de paramètre inconnu #%s. Consultez les logs pour voir son contenu binaire.  
 
-wdl.saveProgress.title=Saving downloaded world
-wdl.saveProgress.chunk.title=Saving chunks
-wdl.saveProgress.chunk.saving=Saving chunk at %s, %s
-wdl.saveProgress.map.title=Saving map item data
-wdl.saveProgress.map.saving=Writing map #%s
-wdl.saveProgress.playerData.title=Saving player data
-wdl.saveProgress.playerData.creatingNBT=Creating player NBT
-wdl.saveProgress.playerData.editingNBT=Editing player NBT
-wdl.saveProgress.playerData.extension=Editing player NBT with extension %s
-wdl.saveProgress.playerData.writingNBT=Writing player NBT
-wdl.saveProgress.worldMetadata.title=Saving world metadata
-wdl.saveProgress.worldMetadata.creatingNBT=Creating world info NBT
-wdl.saveProgress.worldMetadata.editingNBT=Editing world info NBT
-wdl.saveProgress.worldMetadata.extension=Editing world info NBT with extension %s
-wdl.saveProgress.worldMetadata.writingNBT=Writing world info NBT
+wdl.saveProgress.title=Sauvegarde des chunks téléchargés
+wdl.saveProgress.chunk.title=Sauvegarde des chunks
+wdl.saveProgress.chunk.saving=Sauvegarde du chunk aux coordonnées %s, %s
+wdl.saveProgress.map.title=Sauvegarde des données pour les cartes items
+wdl.saveProgress.map.saving=Écriture de la carte #%s
+wdl.saveProgress.playerData.title=Sauvegarde des données du joueur
+wdl.saveProgress.playerData.creatingNBT=Création des données NBT du joueur
+wdl.saveProgress.playerData.editingNBT=Édition des données NBT du joueur
+wdl.saveProgress.playerData.extension=Édition des données NBT du joueur avec les extensions %s
+wdl.saveProgress.playerData.writingNBT=Écriture des données NBT du joueur
+wdl.saveProgress.worldMetadata.title=Sauvegarde des métadonnées du monde
+wdl.saveProgress.worldMetadata.creatingNBT=Création des données NBT pour les informations du monde
+wdl.saveProgress.worldMetadata.editingNBT=Édition des données NBT pour les informations du monde
+wdl.saveProgress.worldMetadata.extension=Édition des données NBT pour les informations du monde par les extensions %s
+wdl.saveProgress.worldMetadata.writingNBT=Écriture des données NBT pour les informations du monde
 wdl.saveProgress.extension.title=Extension: %s
-wdl.saveProgress.flushingIO.title=Procrastinating...
-wdl.saveProgress.flushingIO.subtitle=(Waiting for ThreadedFileIOBase to finish)
-wdl.saveProgress.backingUp.title.zip=Backing up the world (creating zip)
-wdl.saveProgress.backingUp.title.folder=Backing up the world (copying folder)
-wdl.saveProgress.backingUp.preparing=Preparing...
-wdl.saveProgress.backingUp.file=Copying %s
+wdl.saveProgress.flushingIO.title=En attente...
+wdl.saveProgress.flushingIO.subtitle=(En attente que ThreadedFileIOBase ai terminé)
+wdl.saveProgress.backingUp.title.zip=Création d'une backup du monde (création du zip)
+wdl.saveProgress.backingUp.title.folder=Création d'une backup du monde (copie du dossier)
+wdl.saveProgress.backingUp.preparing=Preparation...
+wdl.saveProgress.backingUp.file=En train de copier %s
 
-wdl.props.global.title=These are the default settings used across all servers when the individual server has not yet had a setting set.  You can manually modify them, if you want.
-wdl.props.base.title=These settings are shared across an entire server.  If multiworld is enabled, they act as the default values for the individual world properties; otherwise, they are used directly.
-wdl.props.world.title=These settings are used for a single world in a multiworld server.
+wdl.props.global.title=Ces paramètres sont ceux par défaut quand les serveurs individuels n'ont pas modifié leurs paramètres. Vous pouvez les modifier si vous voulez.
+wdl.props.base.title=Ces paramètres sont utilisés sur un serveur entier. Si le multimonde est activé, ils agissent comme les paramètres par défaut pour chaque monde. Sinon, ils sont utilisés directement.
+wdl.props.world.title=Ces paramètres sont utilisés pour un seul monde dans un serveur multimonde.
 
 #Some of these messages are using format substitutions, so that special coloring can be added.
-wdl.intro.success=The World Downloader mod has been successfully installed!
-wdl.intro.usage=For information on how to use this mod, please see the %s and the %s.
-wdl.intro.forumsLink=Official Minecraft Forums thread
-wdl.intro.wikiLink=Project Wiki
-wdl.intro.contribute=To report a bug, suggest a feature, contribute code, or help translate, check out %s.
-wdl.intro.githubRepo=GitHub repository
-wdl.intro.stolen=%s: If you downloaded this mod from a location other than the Minecraft Forums or GitHub (or another site on %s), you may have used a site that is %s redistributing this mod.
-wdl.intro.redistributionList=the redistribution list
-wdl.intro.warning=WARNING
-wdl.intro.illegally=ILLEGALLY
-wdl.intro.stolenBeware=Beware of such sites, as they can include malware.  %s
-wdl.intro.stopModReposts=More information: StopModReposts!
+wdl.intro.success=Le World Downloader mod a été installé avec succès!
+wdl.intro.usage=Pour plus d'informations sur comment utiliser ce mod, veuillez consulter le %s et le %s.
+wdl.intro.forumsLink=Thread officiel Minecraft Forums
+wdl.intro.wikiLink=Wiki du projet
+wdl.intro.contribute=Pour notifier un bug, suggérer une fonctionnalité, contribuer au code ou aider à traduire, regardez %s.
+wdl.intro.githubRepo=Repo Github
+wdl.intro.stolen=%s: Si vous avez téléchargé ce mod depuis un autre endroit que le thread Minecraft Forums ou que Github (ou un autre site sur %s), vous avez possiblement utilisé un site qui redistribue %s ce mod.
+wdl.intro.redistributionList=la liste de redistribution
+wdl.intro.warning=ATTENTIONS
+wdl.intro.illegally=ILLEGALEMENT
+wdl.intro.stolenBeware=Faites attentions à ces sites, car ils peuvent contenir des logiciels malveillants.  %s
+wdl.intro.stopModReposts=Plus d'informations: StopModReposts!


### PR DESCRIPTION
added a check to prevent empty save folder names

Empty save folder names can cause weird & unwanted behavior like zipping the whole .minecraft folder, so added a throw exception on it. This should now never happen (as there's a check for empty strings & nulls) but you never know

Also while at it, finished the fr_FR translation